### PR TITLE
Vagrant image based on debian-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,23 +2,21 @@ FROM debian:buster-slim
 
 ENV PATH=$PATH:/vagrant/exec
 
-RUN apt-get update -q \
+WORKDIR /src
+ADD . .
+
+RUN set -e \
+ && apt-get update -q \
  && apt-get install -yq wget git procps kmod rsync ruby-dev \
  && wget https://releases.hashicorp.com/vagrant/2.2.4/vagrant_2.2.4_x86_64.deb \
  && dpkg -i vagrant_2.2.4_x86_64.deb \
  && rm vagrant_2.2.4_x86_64.deb \
  && vagrant --version \
  && vagrant plugin install vagrant-env \
- && mkdir /src
-
-WORKDIR /src
-ADD . .
-
-RUN set -e \
  && gem build vagrant-vmck.gemspec \
  && vagrant plugin install vagrant-vmck-*.gem \
  && gem_dir="$(ls -d /root/.vagrant.d/gems/*/gems/vagrant-vmck-*)" \
  && rm -rf "$gem_dir" \
  && ln -s /src "$gem_dir" \
- && apt-get purge -y ruby-dev \
+ && apt-get purge -y wget ruby-dev \
  && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,16 @@
-FROM alpine:3.10.1
-
-RUN apk add ruby ruby-dev ruby-bundler ruby-json rsync gcc g++ make git libc-dev openssh bash
+FROM debian:buster-slim
 
 ENV PATH=$PATH:/vagrant/exec
 
-RUN git clone https://github.com/hashicorp/vagrant.git \
- && cd vagrant \
- && git checkout v2.2.4 \
- && bundle install \
- && bundle --binstubs exec \
+RUN apt-get update -q \
+ && apt-get install -yq wget git procps kmod rsync ruby-dev \
+ && wget https://releases.hashicorp.com/vagrant/2.2.4/vagrant_2.2.4_x86_64.deb \
+ && dpkg -i vagrant_2.2.4_x86_64.deb \
+ && rm vagrant_2.2.4_x86_64.deb \
  && vagrant --version \
- && vagrant plugin install vagrant-env
+ && vagrant plugin install vagrant-env \
+ && mkdir /src
 
-RUN mkdir /src
 WORKDIR /src
 ADD . .
 
@@ -21,4 +19,6 @@ RUN set -e \
  && vagrant plugin install vagrant-vmck-*.gem \
  && gem_dir="$(ls -d /root/.vagrant.d/gems/*/gems/vagrant-vmck-*)" \
  && rm -rf "$gem_dir" \
- && ln -s /src "$gem_dir"
+ && ln -s /src "$gem_dir" \
+ && apt-get purge -y ruby-dev \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
@mgax I used debian-slim. It's larger by 50 mb uncompressed and 5 mb compressed and as a plus we use the official installation.
```
vmck/vagrant-vmck   debian-slim         33fa449207b7        3 minutes ago       373MB
vmck/vagrant-vmck   latest              56948a284e2e        2 days ago          324MB


debian-slim 140 MB
latest 135 MB

```