### PR TITLE
Redirect stdout and stderr same file

### DIFF
--- a/submission/launch.sh
+++ b/submission/launch.sh
@@ -13,7 +13,7 @@ chmod +x script.sh
 vagrant up
 (
 set +e
-vagrant ssh -- 'cd /vagrant; ./script.sh' 1> result.out 2> result.err
+vagrant ssh -- 'cd /vagrant; ./script.sh' &> result.out
 echo $? > result.exit_code
 )
 
@@ -21,15 +21,10 @@ exit_code=$(cat result.exit_code)
 base64 result.out > stdout.tmp
 cat stdout.tmp | tr -d '\n' > stdout
 
-base64 result.err > stderr.tmp
-cat stderr.tmp | tr -d '\n' > stderr
-
-
 jq -n \
     --rawfile out stdout \
-    --rawfile err stderr \
     --arg code $exit_code \
-    '{stdout: $out, stderr: $err, exit_code: $code,}' > out.json
+    '{stdout: $out, exit_code: $code,}' > out.json
 
 curl -X POST "${VMCK_CALLBACK_URL}" -d @out.json \
      --header "Content-Type: application/json"


### PR DESCRIPTION
Fixes [this](https://github.com/vmck/acs-interface/issues/95).
Redirect stderr and stdout to the same output file.

This PR should be merged alongside [this PR](https://github.com/vmck/acs-interface/pull/115)